### PR TITLE
Default CLI skills root to ~/.skillz

### DIFF
--- a/src/skillz/_server.py
+++ b/src/skillz/_server.py
@@ -53,6 +53,7 @@ LOGGER = logging.getLogger("skillz")
 FRONT_MATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)", re.DOTALL)
 SKILL_MARKDOWN = "SKILL.md"
 DEFAULT_TIMEOUT = 60.0
+DEFAULT_SKILLS_ROOT = Path("~/.skillz")
 SERVER_NAME = "Skillz MCP Server"
 SERVER_VERSION = __version__
 
@@ -637,7 +638,10 @@ def list_skills(registry: SkillRegistry) -> None:
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the Skillz MCP server.")
     parser.add_argument(
-        "skills_root", type=Path, help="Directory containing skill folders"
+        "skills_root",
+        type=Path,
+        nargs="?",
+        help=f"Directory containing skill folders (default: {DEFAULT_SKILLS_ROOT})",
     )
     parser.add_argument(
         "--timeout",
@@ -669,7 +673,12 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="List parsed skills and exit without starting the server",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    skills_root = args.skills_root or DEFAULT_SKILLS_ROOT
+    if not isinstance(skills_root, Path):
+        skills_root = Path(skills_root)
+    args.skills_root = skills_root.expanduser()
+    return args
 
 
 def main(argv: Optional[list[str]] = None) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,23 @@
 from pathlib import Path
 
+import pytest
+
 from skillz import parse_args
 
 
-def test_parse_args_defaults(tmp_path: Path) -> None:
+def test_parse_args_defaults_to_home_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_home = Path("/tmp/fake-home")
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    args = parse_args([])
+
+    assert args.skills_root == fake_home / ".skillz"
+    assert args.timeout == 60.0
+    assert args.transport == "stdio"
+    assert args.list_skills is False
+
+
+def test_parse_args_custom_root(tmp_path: Path) -> None:
     args = parse_args([str(tmp_path)])
 
     assert args.skills_root == Path(tmp_path)


### PR DESCRIPTION
## Summary
- default the CLI skills root argument to ~/.skillz when omitted and expand user-provided paths
- update the CLI tests to cover the new default and ensure explicit paths still work

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa535ed448832eb66382e688bb8b63