### PR TITLE
Add CI workflow to run tests on merges and PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: CI Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up uv with Python 3.14
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          python-version: "3.14"
+      - name: Sync dependencies
+        run: uv sync
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the test suite with Python 3.14
- trigger the workflow on pushes to main, pull requests, and manual dispatches

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa667d6aec832ebfa648b98ab5a22c