### PR TITLE
Refactor: MCP resource-only access for Skillz

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "skillz"
-version = "0.1.0"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Overview

This PR refactors the Skillz MCP server to ensure that tool responses and instructions never expose absolute filesystem paths. Instead, resources are advertised and consumed exclusively via MCP resource URIs.

## Changes

### Core Implementation
- **Removed absolute paths from SkillResourceMetadata TypedDict**: The path field has been removed, keeping only relative_path, uri, and runnable
- **Updated register_skill_resources()**: Now only emits relative paths and URIs in metadata
- **Updated register_skill_tool()**: 
  - Removed legacy_paths variable entirely
  - resource_entries now only contain relative_path, uri, and runnable
  - script_entries now only contain relative_path and uri
  - available_resources now only contains URIs (no filesystem paths)

### Documentation/Guidance
- **Enhanced guidance text**: Now explicitly requires resource access via MCP protocol and instructs clients to use ctx.read_resource(uri)
- **Updated call_instructions**: Clarifies script invocation using relative paths and resource reading via URIs

### Tests
- Updated test expectations to match the new URI-only schema
- Added regression test to ensure no absolute paths leak into payloads
- All 7 tests pass successfully

## Benefits
1. **Universal compatibility**: Resources work regardless of where the skill directory is located
2. **Cleaner abstraction**: Clients interact with resources through the MCP protocol, not filesystem paths
3. **Security**: Prevents accidental exposure of system paths
4. **Consistency**: All resource access follows the same pattern via ctx.read_resource(uri)

## Internal Note
Internally, the server still maintains the mapping from URIs to absolute paths for serving resources and running scripts. These paths are only used server-side and never exposed in tool payloads.
