### PR TITLE
feat: add execute_command tool for skill script execution

### DIFF
--- a/src/skillz/_server.py
+++ b/src/skillz/_server.py
@@ -179,9 +179,10 @@ class SkillResourceMetadata(TypedDict):
 
 
 def slugify(value: str) -> str:
-    """Convert names into stable slug identifiers."""
-
-    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    """Convert names into stable slug identifiers, preserving Chinese characters."""
+    # Replace whitespace and special characters with hyphens, but preserve Unicode letters and digits
+    # \w in Python regex matches Unicode word characters (letters, digits, underscore)
+    cleaned = re.sub(r"[^\w]+", "-", value.strip(), flags=re.UNICODE).strip("-")
     return cleaned or "skill"
 
 

--- a/src/skillz/_server.py
+++ b/src/skillz/_server.py
@@ -179,10 +179,12 @@ class SkillResourceMetadata(TypedDict):
 
 
 def slugify(value: str) -> str:
-    """Convert names into stable slug identifiers, preserving Chinese characters."""
-    # Replace whitespace and special characters with hyphens, but preserve Unicode letters and digits
-    # \w in Python regex matches Unicode word characters (letters, digits, underscore)
-    cleaned = re.sub(r"[^\w]+", "-", value.strip(), flags=re.UNICODE).strip("-")
+    """
+    Convert names into stable slug identifiers.
+    https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names
+    """
+
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
     return cleaned or "skill"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "skillz"
-version = "0.1.9"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
When using http or sse transport, the scripts in the skills might not be accessible by the MCP client. So we need to add a tool that allows the client to run the scripts.

- Add execute_command MCP tool for running scripts from skill resources
- Add subprocess import and validation logic for script execution
- Add timeout support (default 30s, max 300s) with configurable working directory
- Add resource path validation to ensure only skill scripts can be executed
- Update server instructions to document script execution capability

The new tool provides a secure way to execute skill-bundled scripts with proper validation, timeout handling, and error reporting. Only scripts that are part of loaded skill resources can be executed, preventing arbitrary command execution.